### PR TITLE
Set missing env var CONNECT_REST_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     environment:
       - CONNECT_BOOTSTRAP_SERVERS=broker:19092
       - CONNECT_REST_ADVERTISED_HOST_NAME=connect
+      - CONNECT_REST_PORT=8083
       - CONNECT_GROUP_ID=connect
       - CONNECT_CONFIG_STORAGE_TOPIC=_connect_configs
       - CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR=1


### PR DESCRIPTION
This environment variable is required by `/etc/confluent/docker/healthcheck.sh` and if not set, the `kafka-connect-sqs-connect-1` service stays in `running (starting)` status for 8 minutes, and transitions to `unhealthy` after that.