### PR TITLE
create persistent credentials provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <!-- latest version as of 2019-01 -->
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-    <junit.version>4.13.1</junit.version>
+    <junit.version>5.8.1</junit.version>
     <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
@@ -54,8 +54,8 @@
         <version>${kafka.connect-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
@@ -66,10 +66,27 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>2.23.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>2.23.4</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
   <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.0.1-jre</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>connect-api</artifactId>
@@ -87,8 +104,16 @@
       <artifactId>aws-java-sdk-sts</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/nordstrom/kafka/connect/auth/AWSAssumeRoleCredentialsProvider.java
+++ b/src/main/java/com/nordstrom/kafka/connect/auth/AWSAssumeRoleCredentialsProvider.java
@@ -2,47 +2,44 @@ package com.nordstrom.kafka.connect.auth;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSSessionCredentials;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import org.apache.kafka.common.Configurable;
-//import org.slf4j.Logger;
-//import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
 public class AWSAssumeRoleCredentialsProvider implements AWSCredentialsProvider, Configurable {
-  //NB: uncomment slf4j imports and field declaration to enable logging.
-//  private static final Logger log = LoggerFactory.getLogger(AWSAssumeRoleCredentialsProvider.class);
-
   public static final String EXTERNAL_ID_CONFIG = "external.id";
   public static final String ROLE_ARN_CONFIG = "role.arn";
   public static final String SESSION_NAME_CONFIG = "session.name";
 
-  private String externalId;
-  private String roleArn;
-  private String sessionName;
+  private STSAssumeRoleSessionCredentialsProvider provider;
 
   @Override
   public void configure(Map<String, ?> map) {
-    externalId = getOptionalField(map, EXTERNAL_ID_CONFIG);
-    roleArn = getRequiredField(map, ROLE_ARN_CONFIG);
-    sessionName = getRequiredField(map, SESSION_NAME_CONFIG);
+    String externalId = getOptionalField(map, EXTERNAL_ID_CONFIG);
+    String roleArn = getRequiredField(map, ROLE_ARN_CONFIG);
+    String sessionName = getRequiredField(map, SESSION_NAME_CONFIG);
+
+    AWSSecurityTokenServiceClientBuilder clientBuilder = AWSSecurityTokenServiceClientBuilder.standard();
+    provider = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)
+            .withStsClient(clientBuilder.build())
+            .withExternalId(externalId)
+            .build();
   }
 
   @Override
   public AWSCredentials getCredentials() {
-    AWSSecurityTokenServiceClientBuilder clientBuilder = AWSSecurityTokenServiceClientBuilder.standard();
-    AWSCredentialsProvider provider = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)
-        .withStsClient(clientBuilder.defaultClient())
-        .withExternalId(externalId)
-        .build();
+    AWSSessionCredentials credentials;
+    credentials = provider.getCredentials();
 
-    return provider.getCredentials();
+    return credentials;
   }
 
   @Override
   public void refresh() {
-    //Nothing to do really, since we are assuming a role.
+    provider.refresh();
   }
 
   private String getOptionalField(final Map<String, ?> map, final String fieldName) {

--- a/src/test/java/com/nordstrom/kafka/connect/auth/AWSAssumeRoleCredentialsProviderTest.java
+++ b/src/test/java/com/nordstrom/kafka/connect/auth/AWSAssumeRoleCredentialsProviderTest.java
@@ -1,0 +1,69 @@
+package com.nordstrom.kafka.connect.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+
+public class AWSAssumeRoleCredentialsProviderTest {
+    @Mock(name = "provider")
+    STSAssumeRoleSessionCredentialsProvider providerMock;
+
+    @InjectMocks
+    AWSAssumeRoleCredentialsProvider provider;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    void testConfigure() {
+        Map<String, String> configs = ImmutableMap.<String, String> builder()
+                .put("external.id", "test-id")
+                .put("role.arn", "aws:iam:test:arn")
+                .put("session.name", "test-session")
+                .build();
+        provider.configure(configs);
+    }
+
+    @Test
+    void testConfigureFailsWithMissingArn() {
+        Map<String, String> configs = ImmutableMap.<String, String> builder()
+                .put("external.id", "test-id")
+                .put("session.name", "test-session")
+                .build();
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> provider.configure(configs));
+        assertEquals("The field 'role.arn' should not be null", exception.getMessage());
+    }
+
+    @Test
+    void testConfigureFailsWithMissingSessionName() {
+        Map<String, String> configs = ImmutableMap.<String, String> builder()
+                .put("external.id", "test-id")
+                .put("role.arn", "aws:iam:test:arn")
+                .build();
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> provider.configure(configs));
+        assertEquals("The field 'session.name' should not be null", exception.getMessage());
+    }
+
+    @Test
+    void testGetCredentials() {
+        provider.getCredentials();
+        verify(providerMock, times(1)).getCredentials();
+    }
+
+    @Test
+    void testRefreshCredentials() {
+        provider.refresh();
+        verify(providerMock, times(1)).refresh();
+    }
+}


### PR DESCRIPTION
Hello! My name is Sarah, and I'm a backend engineer at Zapier. We've been using your SQS sink connector, and we've made a few tweaks to it in our own fork. We are planning to submit a few pull requests with changes that we think would be useful to the community at large.  

This PR introduces a change to the STS Assume Role auth provider. It moves the creation of the `CredentialsProvider` into the `configure` method. The benefit to this change is that the `CredentialsProvider` is only created once. Then `getCredentials` will use cached credentials until they expire, at which point the `refresh` method is called.

At high volumes of events, we found that creating the `CredentialsProvider` in the `getCredentials` method led to AWS rate limits. This change resolved the rate limit errors for us.