### PR TITLE
Allow overriding of endpoint URL through config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Required properties:
 
 Optional properties:
 * `sqs.region`: AWS region of the SQS queue to be read from.
+* `sqs.endpoint`: Override value for the AWS region specific endpoint.
 * `sqs.max.messages`: Maximum number of messages to read from SQS queue for each poll interval. Range is 0 - 10 with default of 1.
 * `sqs.wait.time.seconds`: Duration (in seconds) to wait for a message to arrive in the queue. Default is 1.
 
@@ -59,6 +60,7 @@ Required properties:
 
 Optional properties:
 * `sqs.region`: AWS region of the SQS queue to be written to.
+* `sqs.endpoint`: Override value for the AWS region specific endpoint.
 
 ### Sample Configuration
 ```json

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Required properties:
 
 Optional properties:
 * `sqs.region`: AWS region of the SQS queue to be read from.
-* `sqs.endpoint`: Override value for the AWS region specific endpoint.
+* `sqs.endpoint.url`: Override value for the AWS region specific endpoint.
 * `sqs.max.messages`: Maximum number of messages to read from SQS queue for each poll interval. Range is 0 - 10 with default of 1.
 * `sqs.wait.time.seconds`: Duration (in seconds) to wait for a message to arrive in the queue. Default is 1.
 
@@ -60,7 +60,7 @@ Required properties:
 
 Optional properties:
 * `sqs.region`: AWS region of the SQS queue to be written to.
-* `sqs.endpoint`: Override value for the AWS region specific endpoint.
+* `sqs.endpoint.url`: Override value for the AWS region specific endpoint.
 
 ### Sample Configuration
 ```json

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>com.nordstrom.kafka.connect.sqs</groupId>
   <artifactId>kafka-connect-sqs</artifactId>
   <name>Kafka Connect SQS Sink/Source Connector</name>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/nordstrom/kafka/connect/auth/AWSAssumeRoleCredentialsProvider.java
+++ b/src/main/java/com/nordstrom/kafka/connect/auth/AWSAssumeRoleCredentialsProvider.java
@@ -25,25 +25,25 @@ public class AWSAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
   private String roleArn;
   private String sessionName;
   private String region;
-  private String endpoint;
+  private String endpointUrl;
   @Override
   public void configure(Map<String, ?> map) {
     externalId = getOptionalField(map, EXTERNAL_ID_CONFIG);
     roleArn = getRequiredField(map, ROLE_ARN_CONFIG);
     sessionName = getRequiredField(map, SESSION_NAME_CONFIG);
     region = getRequiredField(map, SqsConnectorConfigKeys.SQS_REGION.getValue());
-    endpoint = getOptionalField(map, SqsConnectorConfigKeys.SQS_ENDPOINT.getValue());
+    endpointUrl = getOptionalField(map, SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue());
   }
 
   @Override
   public AWSCredentials getCredentials() {
     AWSSecurityTokenServiceClientBuilder clientBuilder = null;
-    if(StringUtils.isBlank(endpoint))
+    if(StringUtils.isBlank(endpointUrl))
       clientBuilder = AWSSecurityTokenServiceClientBuilder.standard()
             .withRegion(region);
     else
       clientBuilder = AWSSecurityTokenServiceClientBuilder.standard()
-              .withEndpointConfiguration(new EndpointConfiguration(endpoint, region));
+              .withEndpointConfiguration(new EndpointConfiguration(endpointUrl, region));
 
     AWSCredentialsProvider provider = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)
         .withStsClient(clientBuilder.build())

--- a/src/main/java/com/nordstrom/kafka/connect/auth/AWSAssumeRoleCredentialsProvider.java
+++ b/src/main/java/com/nordstrom/kafka/connect/auth/AWSAssumeRoleCredentialsProvider.java
@@ -3,8 +3,10 @@ package com.nordstrom.kafka.connect.auth;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.nordstrom.kafka.connect.sqs.SqsConnectorConfigKeys;
+import com.nordstrom.kafka.connect.utils.StringUtils;
 import org.apache.kafka.common.Configurable;
 //import org.slf4j.Logger;
 //import org.slf4j.LoggerFactory;
@@ -23,18 +25,26 @@ public class AWSAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
   private String roleArn;
   private String sessionName;
   private String region;
+  private String endpoint;
   @Override
   public void configure(Map<String, ?> map) {
     externalId = getOptionalField(map, EXTERNAL_ID_CONFIG);
     roleArn = getRequiredField(map, ROLE_ARN_CONFIG);
     sessionName = getRequiredField(map, SESSION_NAME_CONFIG);
     region = getRequiredField(map, SqsConnectorConfigKeys.SQS_REGION.getValue());
+    endpoint = getOptionalField(map, SqsConnectorConfigKeys.SQS_ENDPOINT.getValue());
   }
 
   @Override
   public AWSCredentials getCredentials() {
-    AWSSecurityTokenServiceClientBuilder clientBuilder = AWSSecurityTokenServiceClientBuilder.standard()
+    AWSSecurityTokenServiceClientBuilder clientBuilder = null;
+    if(StringUtils.isBlank(endpoint))
+      clientBuilder = AWSSecurityTokenServiceClientBuilder.standard()
             .withRegion(region);
+    else
+      clientBuilder = AWSSecurityTokenServiceClientBuilder.standard()
+              .withEndpointConfiguration(new EndpointConfiguration(endpoint, region));
+
     AWSCredentialsProvider provider = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, sessionName)
         .withStsClient(clientBuilder.build())
         .withExternalId(externalId)

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsClient.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsClient.java
@@ -25,6 +25,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.amazonaws.services.sqs.model.DeleteMessageRequest;
@@ -34,6 +35,9 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
+
+import com.nordstrom.kafka.connect.utils.StringUtils;
+
 
 public class SqsClient {
   private final Logger log = LoggerFactory.getLogger(this.getClass());
@@ -55,9 +59,15 @@ public class SqsClient {
     } catch ( Exception e ) {
       log.error("Problem initializing provider", e);
     }
+
     final AmazonSQSClientBuilder builder = AmazonSQSClientBuilder.standard();
+    if(StringUtils.isBlank(config.getEndpoint())) {
+      builder.setRegion(config.getRegion());
+    } else {
+      builder.setEndpointConfiguration(new EndpointConfiguration(config.getEndpoint(), config.getRegion()));
+    }
+
     builder.setCredentials(provider);
-    builder.setRegion(config.getRegion());
 
 //    // If there's an AWS credentials profile and/or region configured in the
 //    // environment we will use it.

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsClient.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsClient.java
@@ -61,10 +61,10 @@ public class SqsClient {
     }
 
     final AmazonSQSClientBuilder builder = AmazonSQSClientBuilder.standard();
-    if(StringUtils.isBlank(config.getEndpoint())) {
+    if(StringUtils.isBlank(config.getEndpointUrl())) {
       builder.setRegion(config.getRegion());
     } else {
-      builder.setEndpointConfiguration(new EndpointConfiguration(config.getEndpoint(), config.getRegion()));
+      builder.setEndpointConfiguration(new EndpointConfiguration(config.getEndpointUrl(), config.getRegion()));
     }
 
     builder.setCredentials(provider);

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -10,14 +10,14 @@ abstract class SqsConnectorConfig extends AbstractConfig {
     private final String queueUrl;
     private final String topics;
     private final String region;
-    private final String endpoint;
+    private final String endpointUrl;
 
     public SqsConnectorConfig(ConfigDef configDef, Map<?, ?> originals) {
         super(configDef, originals);
         queueUrl = getString(SqsConnectorConfigKeys.SQS_QUEUE_URL.getValue());
         topics = getString(SqsConnectorConfigKeys.TOPICS.getValue());
         region = getString(SqsConnectorConfigKeys.SQS_REGION.getValue());
-        endpoint = getString(SqsConnectorConfigKeys.SQS_ENDPOINT.getValue());
+        endpointUrl = getString(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue());
     }
 
     public String getQueueUrl() {
@@ -31,7 +31,7 @@ abstract class SqsConnectorConfig extends AbstractConfig {
     public String getRegion()  {
         return region;
     }
-    public String getEndpoint()  {
-        return endpoint;
+    public String getEndpointUrl()  {
+        return endpointUrl;
     }
 }

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -10,12 +10,14 @@ abstract class SqsConnectorConfig extends AbstractConfig {
     private final String queueUrl;
     private final String topics;
     private final String region;
+    private final String endpoint;
 
     public SqsConnectorConfig(ConfigDef configDef, Map<?, ?> originals) {
         super(configDef, originals);
         queueUrl = getString(SqsConnectorConfigKeys.SQS_QUEUE_URL.getValue());
         topics = getString(SqsConnectorConfigKeys.TOPICS.getValue());
         region = getString(SqsConnectorConfigKeys.SQS_REGION.getValue());
+        endpoint = getString(SqsConnectorConfigKeys.SQS_ENDPOINT.getValue());
     }
 
     public String getQueueUrl() {
@@ -28,5 +30,8 @@ abstract class SqsConnectorConfig extends AbstractConfig {
 
     public String getRegion()  {
         return region;
+    }
+    public String getEndpoint()  {
+        return endpoint;
     }
 }

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
@@ -25,6 +25,7 @@ public enum SqsConnectorConfigKeys {
   SQS_WAIT_TIME_SECONDS("sqs.wait.time.seconds"),
   TOPICS("topics"),
   SQS_REGION("sqs.region"),
+  SQS_ENDPOINT("sqs.endpoint"),
 
   // These are not part of the connector configuration proper, but just a convenient
   // place to define the constants.

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
@@ -25,7 +25,7 @@ public enum SqsConnectorConfigKeys {
   SQS_WAIT_TIME_SECONDS("sqs.wait.time.seconds"),
   TOPICS("topics"),
   SQS_REGION("sqs.region"),
-  SQS_ENDPOINT("sqs.endpoint"),
+  SQS_ENDPOINT_URL("sqs.endpoint.url"),
 
   // These are not part of the connector configuration proper, but just a convenient
   // place to define the constants.

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
@@ -43,8 +43,8 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
           "AWS Credentials Provider Class")
       .define(SqsConnectorConfigKeys.SQS_REGION.getValue(), Type.STRING, System.getenv("AWS_REGION"), Importance.HIGH,
           "SQS queue AWS region.")
-      .define(SqsConnectorConfigKeys.SQS_ENDPOINT.getValue(), Type.STRING, Importance.LOW,
-          "SQS queue endpoint, If specified, the connector will override the region specific endpoint with this value.");
+      .define(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue(), Type.STRING, Importance.LOW,
+          "If specified, the connector will override the AWS region specific endpoint URL with this value. Note that this is not the queue URL.");
 
   public static ConfigDef config() {
     return CONFIG_DEF;

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SqsSinkConnectorConfig extends SqsConnectorConfig {
-//  private final Logger log = LoggerFactory.getLogger(this.getClass());
   private static final Logger log = LoggerFactory.getLogger(SqsSinkConnectorConfig.class);
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
@@ -43,7 +42,9 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
           ConfigDef.Width.LONG,
           "AWS Credentials Provider Class")
       .define(SqsConnectorConfigKeys.SQS_REGION.getValue(), Type.STRING, System.getenv("AWS_REGION"), Importance.HIGH,
-          "SQS queue AWS region.");
+          "SQS queue AWS region.")
+      .define(SqsConnectorConfigKeys.SQS_ENDPOINT.getValue(), Type.STRING, Importance.LOW,
+          "SQS queue endpoint, If specified, the connector will override the region specific endpoint with this value.");
 
   public static ConfigDef config() {
     return CONFIG_DEF;

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
@@ -35,9 +35,9 @@ public class SqsSourceConnectorConfig extends SqsConnectorConfig {
           "Duration (in seconds) to wait for a message to arrive in the queue. Default is 1.")
       .define(SqsConnectorConfigKeys.TOPICS.getValue(), Type.STRING, Importance.HIGH, "The Kafka topic to be written to.")
       .define(SqsConnectorConfigKeys.SQS_REGION.getValue(), Type.STRING, System.getenv("AWS_REGION"), Importance.HIGH,
-              "SQS queue AWS region.")
-      .define(SqsConnectorConfigKeys.SQS_ENDPOINT.getValue(), Type.STRING, Importance.LOW,
-                  "SQS queue endpoint, If specified, the connector will override the region specific endpoint with this value.");
+          "SQS queue AWS region.")
+      .define(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue(), Type.STRING, Importance.LOW,
+          "If specified, the connector will override the AWS region specific endpoint URL with this value. Note that this is not the queue URL.");
 
 
   public static ConfigDef config() {

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
@@ -35,7 +35,9 @@ public class SqsSourceConnectorConfig extends SqsConnectorConfig {
           "Duration (in seconds) to wait for a message to arrive in the queue. Default is 1.")
       .define(SqsConnectorConfigKeys.TOPICS.getValue(), Type.STRING, Importance.HIGH, "The Kafka topic to be written to.")
       .define(SqsConnectorConfigKeys.SQS_REGION.getValue(), Type.STRING, System.getenv("AWS_REGION"), Importance.HIGH,
-              "SQS queue AWS region.");
+              "SQS queue AWS region.")
+      .define(SqsConnectorConfigKeys.SQS_ENDPOINT.getValue(), Type.STRING, Importance.LOW,
+                  "SQS queue endpoint, If specified, the connector will override the region specific endpoint with this value.");
 
 
   public static ConfigDef config() {

--- a/src/main/java/com/nordstrom/kafka/connect/utils/StringUtils.java
+++ b/src/main/java/com/nordstrom/kafka/connect/utils/StringUtils.java
@@ -1,0 +1,12 @@
+package com.nordstrom.kafka.connect.utils;
+
+public class StringUtils {
+    /**
+     * @see <a href="https://commons.apache.org/proper/commons-lang/apidocs/src-html/org/apache/commons/lang3/StringUtils.html#line.3571">StringUtils.isBlank()</>
+     * @param input
+     * @return true if input String is null, empty or blank.
+     */
+    public static boolean isBlank(String input) {
+        return input == null || input.trim().isEmpty();
+    }
+}


### PR DESCRIPTION
Hello folks,
Firstly thanks for the connector. It is a useful alternative to the proprietary option provided by Confluent. I've been using this connector recently for a proof of concept and it has been working well for me.

I've had the need to override the endpoint URL to get the connector to work with localstack. I've seen a similar request in issue #20. So, here's my PR.

Please take a look and provide some feedback 😄 