### PR TITLE
Adds string messageattributes to headers conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Optional properties:
 * `sqs.max.messages`: Maximum number of messages to read from SQS queue for each poll interval. Range is 0 - 10 with default of 1.
 * `sqs.wait.time.seconds`: Duration (in seconds) to wait for a message to arrive in the queue. Default is 1.
 * `sqs.message.attributes.enabled`: If true, it gets the SQS MessageAttributes and inserts them as Kafka Headers (only string headers are currently supported). Default is false.
-* `sqs.message.attributes.list`: The comma separated list of MessageAttribute names to be included (or "All" to accept all the names). Default is the empty string.
+* `sqs.message.attributes.include.list`: The comma separated list of MessageAttribute names to be included, if empty it includes all the Message Attributes. Default is the empty string.
 
 ### Sample Configuration
 
@@ -64,7 +64,7 @@ Optional properties:
 * `sqs.region`: AWS region of the SQS queue to be written to.
 * `sqs.endpoint.url`: Override value for the AWS region specific endpoint.
 * `sqs.message.attributes.enabled`: If true, it gets the Kafka Headers and inserts them as SQS MessageAttributes (only string headers are currently supported). Default is false.
-* `sqs.message.attributes.list`: The comma separated list of Header names to be included (or "All" to accept all the names). Default is the empty string.
+* `sqs.message.attributes.include.list`: The comma separated list of Header names to be included, if empty it includes all the Headers. Default is the empty string.
 
 ### Sample Configuration
 ```json

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Optional properties:
 * `sqs.endpoint.url`: Override value for the AWS region specific endpoint.
 * `sqs.max.messages`: Maximum number of messages to read from SQS queue for each poll interval. Range is 0 - 10 with default of 1.
 * `sqs.wait.time.seconds`: Duration (in seconds) to wait for a message to arrive in the queue. Default is 1.
+* `sqs.message.attributes.enabled`: If true, it gets the SQS MessageAttributes and inserts them as Kafka Headers (only string headers are currently supported). Default is false.
+* `sqs.message.attributes.list`: The comma separated list of MessageAttribute names to be included (or "All" to accept all the names). Default is the empty string.
 
 ### Sample Configuration
 
@@ -61,6 +63,8 @@ Required properties:
 Optional properties:
 * `sqs.region`: AWS region of the SQS queue to be written to.
 * `sqs.endpoint.url`: Override value for the AWS region specific endpoint.
+* `sqs.message.attributes.enabled`: If true, it gets the Kafka Headers and inserts them as SQS MessageAttributes (only string headers are currently supported). Default is false.
+* `sqs.message.attributes.list`: The comma separated list of Header names to be included (or "All" to accept all the names). Default is the empty string.
 
 ### Sample Configuration
 ```json

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsClient.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsClient.java
@@ -124,7 +124,11 @@ public class SqsClient {
         .withMaxNumberOfMessages(maxMessages).withWaitTimeSeconds(waitTimeSeconds).withAttributeNames("");
 
     if (messageAttributesEnabled) {
-      receiveMessageRequest = receiveMessageRequest.withMessageAttributeNames(messageAttributesList);
+      if (messageAttributesList.size() == 0) {
+        receiveMessageRequest = receiveMessageRequest.withMessageAttributeNames("All");
+      } else {
+        receiveMessageRequest = receiveMessageRequest.withMessageAttributeNames(messageAttributesList);
+      }
     }
 
     final ReceiveMessageResult result = client.receiveMessage(receiveMessageRequest);

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsClient.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsClient.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.sqs.model.*;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
@@ -28,13 +29,6 @@ import org.slf4j.LoggerFactory;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import com.amazonaws.services.sqs.model.DeleteMessageRequest;
-import com.amazonaws.services.sqs.model.DeleteMessageResult;
-import com.amazonaws.services.sqs.model.Message;
-import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
-import com.amazonaws.services.sqs.model.ReceiveMessageResult;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
-import com.amazonaws.services.sqs.model.SendMessageResult;
 
 import com.nordstrom.kafka.connect.utils.StringUtils;
 
@@ -45,6 +39,9 @@ public class SqsClient {
   private final String AWS_FIFO_SUFFIX = ".fifo";
   public static final Class<? extends AWSCredentialsProvider> CREDENTIALS_PROVIDER_CLASS_DEFAULT =
       com.amazonaws.auth.DefaultAWSCredentialsProviderChain.class;
+
+  private final Boolean messageAttributesEnabled;
+  private final List<String> messageAttributesList;
 
   private final AmazonSQS client;
 
@@ -82,6 +79,8 @@ public class SqsClient {
 //    log.info("AmazonSQS using profile={}, region={}", profile, region);
 
     client = builder.build();
+    messageAttributesEnabled = config.getMessageAttributesEnabled();
+    messageAttributesList = config.getMessageAttributesList();
   }
 
   /**
@@ -121,8 +120,13 @@ public class SqsClient {
     //
     // Receive messages from queue
     //
-    final ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(url)
+    ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(url)
         .withMaxNumberOfMessages(maxMessages).withWaitTimeSeconds(waitTimeSeconds).withAttributeNames("");
+
+    if (messageAttributesEnabled) {
+      receiveMessageRequest = receiveMessageRequest.withMessageAttributeNames(messageAttributesList);
+    }
+
     final ReceiveMessageResult result = client.receiveMessage(receiveMessageRequest);
     final List<Message> messages = result.getMessages();
 
@@ -139,9 +143,10 @@ public class SqsClient {
    * @param body      The message to send.
    * @param groupId   Optional group identifier (fifo queues only).
    * @param messageId Optional message identifier (fifo queues only).
+   * @param messageAttributes The message attributes to send.
    * @return
    */
-  public String send(final String url, final String body, final String groupId, final String messageId) {
+  public String send(final String url, final String body, final String groupId, final String messageId, final Map<String, MessageAttributeValue> messageAttributes) {
     log.debug(".send: queue={}, gid={}, mid={}", url, groupId, messageId);
 
     Guard.verifyValidUrl(url);
@@ -151,7 +156,11 @@ public class SqsClient {
     }
     final boolean fifo = isFifo(url);
 
-    final SendMessageRequest request = new SendMessageRequest(url, body);
+    SendMessageRequest request = new SendMessageRequest(url, body);
+    if (messageAttributes != null) {
+      request.setMessageAttributes(messageAttributes);
+    }
+
     if (fifo) {
       Guard.verifyNotNullOrEmpty(groupId, "groupId");
       Guard.verifyNotNullOrEmpty(messageId, "messageId");

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -3,6 +3,9 @@ package com.nordstrom.kafka.connect.sqs;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 abstract class SqsConnectorConfig extends AbstractConfig {
@@ -12,12 +15,20 @@ abstract class SqsConnectorConfig extends AbstractConfig {
     private final String region;
     private final String endpointUrl;
 
+    private final Boolean messageAttributesEnabled;
+
+    private final List<String> messageAttributesList;
+
     public SqsConnectorConfig(ConfigDef configDef, Map<?, ?> originals) {
         super(configDef, originals);
         queueUrl = getString(SqsConnectorConfigKeys.SQS_QUEUE_URL.getValue());
         topics = getString(SqsConnectorConfigKeys.TOPICS.getValue());
         region = getString(SqsConnectorConfigKeys.SQS_REGION.getValue());
         endpointUrl = getString(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue());
+        messageAttributesEnabled = getBoolean(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_ENABLED.getValue());
+
+        String csMessageAttributesList = getString(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_LIST.getValue());
+        messageAttributesList = messageAttributesEnabled ? Arrays.asList(csMessageAttributesList.split(",")) : new ArrayList<>();
     }
 
     public String getQueueUrl() {
@@ -31,7 +42,16 @@ abstract class SqsConnectorConfig extends AbstractConfig {
     public String getRegion()  {
         return region;
     }
+
     public String getEndpointUrl()  {
         return endpointUrl;
+    }
+
+    public Boolean getMessageAttributesEnabled() {
+        return messageAttributesEnabled;
+    }
+
+    public List<String> getMessageAttributesList() {
+        return messageAttributesList;
     }
 }

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -4,7 +4,6 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -27,8 +26,8 @@ abstract class SqsConnectorConfig extends AbstractConfig {
         endpointUrl = getString(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue());
         messageAttributesEnabled = getBoolean(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_ENABLED.getValue());
 
-        String csMessageAttributesList = getString(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_LIST.getValue());
-        messageAttributesList = messageAttributesEnabled ? Arrays.asList(csMessageAttributesList.split(",")) : new ArrayList<>();
+        List<String> csMessageAttributesList = getList(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST.getValue());
+        messageAttributesList = messageAttributesEnabled ? csMessageAttributesList : new ArrayList<>();
     }
 
     public String getQueueUrl() {

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
@@ -26,6 +26,8 @@ public enum SqsConnectorConfigKeys {
   TOPICS("topics"),
   SQS_REGION("sqs.region"),
   SQS_ENDPOINT_URL("sqs.endpoint.url"),
+  SQS_MESSAGE_ATTRIBUTES_ENABLED("sqs.message.attributes.enabled"),
+  SQS_MESSAGE_ATTRIBUTES_LIST("sqs.message.attributes.list"),
 
   // These are not part of the connector configuration proper, but just a convenient
   // place to define the constants.

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
@@ -27,7 +27,7 @@ public enum SqsConnectorConfigKeys {
   SQS_REGION("sqs.region"),
   SQS_ENDPOINT_URL("sqs.endpoint.url"),
   SQS_MESSAGE_ATTRIBUTES_ENABLED("sqs.message.attributes.enabled"),
-  SQS_MESSAGE_ATTRIBUTES_LIST("sqs.message.attributes.list"),
+  SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST("sqs.message.attributes.include.list"),
 
   // These are not part of the connector configuration proper, but just a convenient
   // place to define the constants.

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
@@ -44,7 +44,11 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
       .define(SqsConnectorConfigKeys.SQS_REGION.getValue(), Type.STRING, System.getenv("AWS_REGION"), Importance.HIGH,
           "SQS queue AWS region.")
       .define(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue(), Type.STRING, Importance.LOW,
-          "If specified, the connector will override the AWS region specific endpoint URL with this value. Note that this is not the queue URL.");
+          "If specified, the connector will override the AWS region specific endpoint URL with this value. Note that this is not the queue URL.")
+      .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_ENABLED.getValue(), Type.BOOLEAN, false, Importance.LOW,
+          "If true, it gets the Kafka Headers and inserts them as SQS MessageAttributes (only string headers are currently supported). Default is false.")
+      .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_LIST.getValue(), Type.STRING, "", Importance.LOW,
+          "The comma separated list of Header names to be included (or \"All\" to accept all the names). Default is the empty string.");
 
   public static ConfigDef config() {
     return CONFIG_DEF;

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorConfig.java
@@ -47,8 +47,8 @@ public class SqsSinkConnectorConfig extends SqsConnectorConfig {
           "If specified, the connector will override the AWS region specific endpoint URL with this value. Note that this is not the queue URL.")
       .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_ENABLED.getValue(), Type.BOOLEAN, false, Importance.LOW,
           "If true, it gets the Kafka Headers and inserts them as SQS MessageAttributes (only string headers are currently supported). Default is false.")
-      .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_LIST.getValue(), Type.STRING, "", Importance.LOW,
-          "The comma separated list of Header names to be included (or \"All\" to accept all the names). Default is the empty string.");
+      .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST.getValue(), Type.LIST, "", Importance.LOW,
+          "The comma separated list of Header names to be included, if empty it includes all the Headers. Default is the empty string.");
 
   public static ConfigDef config() {
     return CONFIG_DEF;

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTask.java
@@ -94,7 +94,7 @@ public class SqsSinkConnectorTask extends SinkTask {
         final Headers headers = record.headers();
         messageAttributes = new HashMap<>();
         List<String> attributesList = config.getMessageAttributesList();
-        boolean allNamesEnabled = (attributesList.size() == 1 && attributesList.get(0).equals("All"));
+        boolean allNamesEnabled = (attributesList.size() == 0);
         for(Header header: headers) {
           if(allNamesEnabled || attributesList.contains(header.key())) {
             if(header.schema().equals(Schema.STRING_SCHEMA)) {

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
@@ -37,7 +37,11 @@ public class SqsSourceConnectorConfig extends SqsConnectorConfig {
       .define(SqsConnectorConfigKeys.SQS_REGION.getValue(), Type.STRING, System.getenv("AWS_REGION"), Importance.HIGH,
           "SQS queue AWS region.")
       .define(SqsConnectorConfigKeys.SQS_ENDPOINT_URL.getValue(), Type.STRING, Importance.LOW,
-          "If specified, the connector will override the AWS region specific endpoint URL with this value. Note that this is not the queue URL.");
+          "If specified, the connector will override the AWS region specific endpoint URL with this value. Note that this is not the queue URL.")
+      .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_ENABLED.getValue(), Type.BOOLEAN, false, Importance.LOW,
+          "If true, it gets the SQS MessageAttributes and inserts them as Kafka Headers (only string headers are currently supported). Default is false.")
+      .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_LIST.getValue(), Type.STRING, "", Importance.LOW,
+          "The comma separated list of MessageAttribute names to be included (or \"All\" to accept all the names). Default is the empty string.");
 
 
   public static ConfigDef config() {

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSourceConnectorConfig.java
@@ -40,9 +40,8 @@ public class SqsSourceConnectorConfig extends SqsConnectorConfig {
           "If specified, the connector will override the AWS region specific endpoint URL with this value. Note that this is not the queue URL.")
       .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_ENABLED.getValue(), Type.BOOLEAN, false, Importance.LOW,
           "If true, it gets the SQS MessageAttributes and inserts them as Kafka Headers (only string headers are currently supported). Default is false.")
-      .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_LIST.getValue(), Type.STRING, "", Importance.LOW,
-          "The comma separated list of MessageAttribute names to be included (or \"All\" to accept all the names). Default is the empty string.");
-
+      .define(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST.getValue(), Type.LIST, "", Importance.LOW,
+          "The comma separated list of MessageAttribute names to be included, if empty it includes all the Message Attributes. Default is the empty string.");
 
   public static ConfigDef config() {
     return CONFIG_DEF;


### PR DESCRIPTION
Hello! I'm Mauro, and I work as an engineer for an Italian company called Fatture in Cloud.

We started using your connector to move our SQS messages to AWS MSK (Kafka), but we had the necessity to add a few headers to the Kafka message.
We noticed that the connector didn't support the conversion of SQS Message Attributes to Kafka Headers, so we decided to modify the connector to make it possible. We decided to open this PR because we think it could be helpful to the community, so I hope it is appreciated.

We created the SQS Message Attributes -> Kafka Headers conversion for the Source, and the Kafka Headers -> SQS Message Attributes conversion for the Sink.
Also, we added two options to make it possible to enable/disable the conversion (by default it is disabled) and also to select only a subset of keys that must be included. Following AWS behavior, setting the keys list to "All" makes it possible to convert all the Message Attributes/Headers without filtering.

