### PR TITLE
Allow specifying a partition key from a JSON message body in the source connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -94,6 +93,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba</groupId>
+      <artifactId>fastjson</artifactId>
+      <version>2.0.47</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 abstract class SqsConnectorConfig extends AbstractConfig {
-
     private final String queueUrl;
     private final String topics;
     private final String region;
@@ -17,6 +16,10 @@ abstract class SqsConnectorConfig extends AbstractConfig {
     private final Boolean messageAttributesEnabled;
 
     private final List<String> messageAttributesList;
+
+    private final String messageBodyJSONKey;
+
+    private final String messageBodyType;
 
     public SqsConnectorConfig(ConfigDef configDef, Map<?, ?> originals) {
         super(configDef, originals);
@@ -28,6 +31,8 @@ abstract class SqsConnectorConfig extends AbstractConfig {
 
         List<String> csMessageAttributesList = getList(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST.getValue());
         messageAttributesList = messageAttributesEnabled ? csMessageAttributesList : new ArrayList<>();
+        messageBodyType = getString(SqsConnectorConfigKeys.SQS_MESSAGE_BODY_TYPE.getValue());
+        messageBodyJSONKey = getString(SqsConnectorConfigKeys.SQS_MESSAGE_BODY_JSON_KEY.getValue());
     }
 
     public String getQueueUrl() {
@@ -52,5 +57,13 @@ abstract class SqsConnectorConfig extends AbstractConfig {
 
     public List<String> getMessageAttributesList() {
         return messageAttributesList;
+    }
+
+    public String getMessageBodyJSONKey() {
+        return messageBodyJSONKey;
+    }
+
+    public String getMessageBodyType() {
+        return messageBodyType;
     }
 }

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
@@ -28,6 +28,8 @@ public enum SqsConnectorConfigKeys {
   SQS_ENDPOINT_URL("sqs.endpoint.url"),
   SQS_MESSAGE_ATTRIBUTES_ENABLED("sqs.message.attributes.enabled"),
   SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST("sqs.message.attributes.include.list"),
+  SQS_MESSAGE_BODY_TYPE("sqs.message.body.type"),
+  SQS_MESSAGE_BODY_JSON_KEY("sqs.message.body.json.key"),
 
   // These are not part of the connector configuration proper, but just a convenient
   // place to define the constants.
@@ -35,7 +37,8 @@ public enum SqsConnectorConfigKeys {
   CREDENTIALS_PROVIDER_CLASS_DEFAULT("com.amazonaws.auth.DefaultAWSCredentialsProviderChain"),
   CREDENTIALS_PROVIDER_CONFIG_PREFIX("sqs.credentials.provider."),  //NB: trailing '.'
   SQS_MESSAGE_ID("sqs.message.id"),
-  SQS_MESSAGE_RECEIPT_HANDLE("sqs.message.receipt-handle");
+  SQS_MESSAGE_RECEIPT_HANDLE("sqs.message.receipt-handle"),
+  SQS_MESSAGE_BODY_JSON_TYPE("application/json");
 
   private final String value;
 

--- a/src/main/java/com/nordstrom/kafka/connect/utils/MessageUtils.java
+++ b/src/main/java/com/nordstrom/kafka/connect/utils/MessageUtils.java
@@ -1,0 +1,24 @@
+package com.nordstrom.kafka.connect.utils;
+
+import com.alibaba.fastjson2.JSONObject;
+import com.amazonaws.services.sqs.model.Message;
+import com.alibaba.fastjson2.JSON;
+
+public class MessageUtils {
+    public static String getStringValueFromJSONPath(String jsonPath, Message message) {
+        String messageId = message.getMessageId();
+        if (StringUtils.isBlank(jsonPath)) {
+            return messageId;
+        }
+        String messageBody = message.getBody();
+        if (!JSON.isValid(messageBody)) {
+            return messageId;
+        }
+        JSONObject obj = JSON.parseObject(messageBody);
+        Object result = obj.getByPath(jsonPath);
+        if (result == null) {
+            return messageId;
+        }
+        return result.toString();
+    }
+}


### PR DESCRIPTION
#### Requirement
Currently, source connectors can only use the SQS message ID as a partition key. 
This commit changes that by allowing the user to specify parsing JSON message bodies for the purpose of extracting a key.
This PR resolves #38 .

#### Solution
We're adding two configuration keys:

* [optional] `sqs.message.body.type`: allow configuring the type of the message body (e.g `application/json`)
* [optional] `sqs.message.body.json.key`: allow configuring a JSON Path to extract the key from the JSON body of the SQS message

If the configured message body type is `application/json` and a value can be extracted using the configured JSON path, that will be the message key. If not, the connector falls back to the message ID.