### PR TITLE
feature: Allow configuring partition key from a MessageAttribute

### DIFF
--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfig.java
@@ -18,6 +18,8 @@ abstract class SqsConnectorConfig extends AbstractConfig {
 
     private final List<String> messageAttributesList;
 
+    private final String messageAttributePartitionKey;
+
     public SqsConnectorConfig(ConfigDef configDef, Map<?, ?> originals) {
         super(configDef, originals);
         queueUrl = getString(SqsConnectorConfigKeys.SQS_QUEUE_URL.getValue());
@@ -28,6 +30,7 @@ abstract class SqsConnectorConfig extends AbstractConfig {
 
         List<String> csMessageAttributesList = getList(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST.getValue());
         messageAttributesList = messageAttributesEnabled ? csMessageAttributesList : new ArrayList<>();
+        messageAttributePartitionKey = getString(SqsConnectorConfigKeys.SQS_MESSAGE_ATTRIBUTE_PARTITION_KEY.getValue());
     }
 
     public String getQueueUrl() {
@@ -52,5 +55,9 @@ abstract class SqsConnectorConfig extends AbstractConfig {
 
     public List<String> getMessageAttributesList() {
         return messageAttributesList;
+    }
+
+    public String getMessageAttributePartitionKey() {
+        return messageAttributePartitionKey;
     }
 }

--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsConnectorConfigKeys.java
@@ -28,6 +28,7 @@ public enum SqsConnectorConfigKeys {
   SQS_ENDPOINT_URL("sqs.endpoint.url"),
   SQS_MESSAGE_ATTRIBUTES_ENABLED("sqs.message.attributes.enabled"),
   SQS_MESSAGE_ATTRIBUTES_INCLUDE_LIST("sqs.message.attributes.include.list"),
+  SQS_MESSAGE_ATTRIBUTE_PARTITION_KEY("sqs.message.attributes.partition.key"),
 
   // These are not part of the connector configuration proper, but just a convenient
   // place to define the constants.


### PR DESCRIPTION
#### Requirement
Currently, source connectors can only use the SQS message ID as a partition key.
This PR allows extracting a key from the SQS message attributes. It resolves #38 .

#### Solution

When message attributes are enabled in the config, allow the user to specify a message attribute to use as the partition key.
A string value is extracted from the specified message attribute if it exists. If the message attribute is unspecified (default) or does not exist then the connector falls back to using the SQS message ID as the partition key. 

Caveats:
 * Only String-valued message attributes are supported.
 * Kafka messages will have headers (because of enabling message attributes).