### PR TITLE
Update Kafka Connect and AWS SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ The SQS connector plugin provides the ability to use AWS SQS queues as both a so
 ## Compatibility Matrix
 |Connector version|Kafka Connect API|AWS SDK|
 |:---|:---|:---|
-|1.1.0|2.2.0|1.11.501|
-|1.2.0|2.3.0|1.11.924|
-|1.3.0|2.8.1|1.11.1034|
 |1.4.0|3.1.1|1.12.241|
 |1.5.0|3.3.2|1.12.409|
+|1.6.0|3.4.1|1.12.669|
 
-Due to a compatibility issue with [Apache httpcomponents](http://hc.apache.org/), connector versions 1.1.0 and earlier may not work with Kafka Connect versions greater than 2.2
+We don't recommend running the connector on versions of Kafka Connect prior to 3.0.
 
 # Building
 You can build the connector with Maven using the standard lifecycle goals:

--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
     <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
 
-    <aws-java-sdk.version>1.12.409</aws-java-sdk.version>
-    <kafka.connect-api.version>3.3.2</kafka.connect-api.version>
+    <aws-java-sdk.version>1.12.669</aws-java-sdk.version>
+    <kafka.connect-api.version>3.4.1</kafka.connect-api.version>
     <slf4j.version>1.7.36</slf4j.version>
   </properties>
 


### PR DESCRIPTION
- Update runtime dependency versions for Kafka Connect and AWS SDK
- Drop compatibility references to 1.3 and earlier