### PR TITLE
Bump aws sdk to 1.12.778 to support EKS Pod Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ queue into a Kafka topic) or sink (out of a Kafka topic into an SQS queue).
 |:---|:---|:---|
 |1.4|3.1.1|1.12.241|
 |1.5|3.3.2|1.12.409|
-|1.6|3.4.1|1.12.669|
+|1.6|3.4.1|1.12.778|
 
 ## Building the distributable
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <groupId>com.nordstrom.kafka.connect.sqs</groupId>
   <artifactId>kafka-connect-sqs</artifactId>
   <name>Kafka Connect SQS Sink/Source Connector</name>
-  <version>1.6.2</version>
+  <version>1.6.3</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -41,7 +41,7 @@
     <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
     <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
 
-    <aws-java-sdk.version>1.12.669</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.778</aws-java-sdk.version>
     <kafka.connect-api.version>3.4.1</kafka.connect-api.version>
     <slf4j.version>1.7.36</slf4j.version>
   </properties>


### PR DESCRIPTION
The current version of the AWS SDK in this project does not support AWS EKS Pod Identity as an authentication method. This was added in `1.12.746` per https://github.com/aws/aws-sdk-java/issues/3062#issuecomment-2192771284

# summary of changes

* Bump AWS SDK from `1.12.669` to `1.12.778` one of the latest versions in `1.12` 