### PR TITLE
SinkTask - Use `RetriableException` to avoid losing messages 

### DIFF
--- a/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTask.java
+++ b/src/main/java/com/nordstrom/kafka/connect/sqs/SqsSinkConnectorTask.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map ;
 
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
@@ -112,7 +113,7 @@ public class SqsSinkConnectorTask extends SinkTask {
 
           log.debug( ".put.OK:message-id={}, queue.url={}, sqs-group-id={}, sqs-message-id={}", gid, mid,
               config.getQueueUrl(), sid ) ;
-        } catch ( final RuntimeException e ) {
+        } catch ( final RetriableException e ) {
           log.error( "An Exception occurred while sending message {} to target url {}:", mid, config.getQueueUrl(),
               e ) ;
         }


### PR DESCRIPTION
Hello 👋, 
I hope this helps.

When the `client.send` fails during the `put` operation, as it is asynchronous inside Kafka Connect, it might commit offsets before getting the error, so messages might be lost.

As an example, this is what happens when using a wrong SQS URL
![imagen](https://github.com/user-attachments/assets/c02a3ffe-f5aa-4f75-b994-a7e92c35c4f2)

It consumes a few messages and then it stops. 


[According to the docs](https://github.com/a0x8o/kafka/blob/master/connect/api/src/main/java/org/apache/kafka/connect/sink/SinkTask.java#L90-L101), returning a `RetriableException` rather than RuntimeException forces Kafka Connect to retry the operation, which also ensures that messages are not committed. 

This change fixes https://github.com/Nordstrom/kafka-connect-sqs/issues/3 


A simple way of testing this is to create a new connector with a wrong SQS URL, the current code starts consuming and committing some offsets until it detects the exception and stops. 
I tried this change in a fork and it fails before committing offsets, so no messages are lost.



